### PR TITLE
Further testing/modification to the Safety Zone system

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -18,7 +18,7 @@ public final class Constants {
         public static final double safetyZoneMinX = 0;
         public static final double safetyZoneMaxX = 2;
         public static final double safetyZoneMinY = 0;
-        public static final double safetyZoneMaxY = 99;
+        public static final double safetyZoneMaxY = 99; // TODO: FIND THE ACTUAL VALUES
 
         public static final double outsideZoneMultiplier = 0.1;
     }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -16,9 +16,9 @@ public final class Constants {
     public static final class RegistrationSafety{
         public static final boolean safetyZoneEnabled = true;
         public static final double safetyZoneMinX = 0;
-        public static final double safetyZoneMaxX = 1;
+        public static final double safetyZoneMaxX = 2;
         public static final double safetyZoneMinY = 0;
-        public static final double safetyZoneMaxY = 1;
+        public static final double safetyZoneMaxY = 99;
 
         public static final double outsideZoneMultiplier = 0.1;
     }

--- a/src/main/java/frc/robot/subsystems/Swerve.java
+++ b/src/main/java/frc/robot/subsystems/Swerve.java
@@ -55,12 +55,12 @@ public class Swerve extends SubsystemBase {
         if(Constants.RegistrationSafety.safetyZoneEnabled){
             Pose2d estimatedPose = getPose();
             if(
-            estimatedPose.getX() < Constants.RegistrationSafety.safetyZoneMinX || 
-            estimatedPose.getX() > Constants.RegistrationSafety.safetyZoneMaxX ||
-            estimatedPose.getY() < Constants.RegistrationSafety.safetyZoneMinY ||
-            estimatedPose.getY() > Constants.RegistrationSafety.safetyZoneMaxY  ){
+            Math.abs(estimatedPose.getX()) < Constants.RegistrationSafety.safetyZoneMinX || 
+            Math.abs(estimatedPose.getX()) > Constants.RegistrationSafety.safetyZoneMaxX ||
+            Math.abs(estimatedPose.getY()) < Constants.RegistrationSafety.safetyZoneMinY ||
+            Math.abs(estimatedPose.getY()) > Constants.RegistrationSafety.safetyZoneMaxY  ){
                 double multiplier = Constants.RegistrationSafety.outsideZoneMultiplier; //Set the value in a variable so the lines are not so long
-                translation = new Translation2d(translation.getX() * multiplier, translation.getY() * multiplier);
+                translation = new Translation2d(translation.getX() * 0.1, translation.getY() * 0.1);
                 rotation = 0; // UNTESTED
             }
         }

--- a/src/main/java/frc/robot/subsystems/Swerve.java
+++ b/src/main/java/frc/robot/subsystems/Swerve.java
@@ -61,7 +61,7 @@ public class Swerve extends SubsystemBase {
             estimatedPose.getY() > Constants.RegistrationSafety.safetyZoneMaxY  ){
                 double multiplier = Constants.RegistrationSafety.outsideZoneMultiplier; //Set the value in a variable so the lines are not so long
                 translation = new Translation2d(translation.getX() * multiplier, translation.getY() * multiplier);
-                rotation = rotation * multiplier;
+                rotation = 0; // UNTESTED
             }
         }
         


### PR DESCRIPTION
The zone min/max values in Constants need further testing to pin down the actual values and likely will change on registration day.

The detection of the position relative to the min/max values should be correct.

The multiplier value is hardcoded directly instead of calling it from constants. (not sure why)